### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -1,4 +1,4 @@
-# This workflow is triggered every time a change is pushed to any branches 
+# This workflow is triggered every time a change is pushed to any branches
 # Github actions command reference: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 name: On Code Change (PR)
 
@@ -34,7 +34,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: 'jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node'
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -27,7 +27,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: 'jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node'
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -45,7 +45,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: 'jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node'
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -7,62 +7,8 @@ on:
     types: [prereleased]
 
 jobs:
-  on-release:
-    runs-on: ubuntu-latest
-
-    # The cimg-mvn-cache is an image containing a .m2 folder warmed-up
-    # with common Jahia dependencies. Using this prevents maven from
-    # downloading the entire world when building.
-    # More on https://github.com/Jahia/cimg-mvn-cache
-    container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    steps:
-      # Providing the SSH PRIVATE of a user part of an admin group
-      # is necessary to bypass PR checks
-      - uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
-
-      # Setting up the SSH agent to be able to commit back to the repository
-      # https://github.com/webfactory/ssh-agent
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
-
-      - uses: jahia/jahia-modules-action/release@v2
-        name: Release Module
-        with:
-          github_slug: Jahia/jahia-commons
-          primary_release_branch: master
-          release_id: ${{ github.event.release.id }}
-          release_version: ${{ github.event.release.tag_name }}
-          github_api_token: ${{ secrets.GH_API_TOKEN }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-
-      - uses: jahia/jahia-modules-action/update-signature@v2
-        with:
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
-          force_signature: true
-
-      - uses: jahia/jahia-modules-action/release-publication@v2
-        name: Publish Module
-        with:
-          module_id: jahia-commons
-          release_version: ${{ github.event.release.tag_name }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-
-      # Tmate only starts if any of the previous steps fails.
-      # Be careful since it also means that if a step fails the workflow will
-      # keep running until it reaches the timeout
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
+  release-module:
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-release-module.yml@v2
+    secrets: inherit 
+    with:
+      primary_release_branch: "master"

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,13 @@
     <artifactId>jahia-commons</artifactId>
     <version>1.0.9-SNAPSHOT</version>
     <name>Jahia Commons</name>
+    <!-- TODO:  this project is actually not used at all as a bundle. https://github.com/Jahia/jahia-commons/issues/32 -->
     <packaging>bundle</packaging>
 
     <properties>
-        <osgi.version>4.3.0</osgi.version>
-        <jahia.site.path>${project.build.outputDirectory}/site</jahia.site.path>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <jahia.nexus.staging.repository.id>64277f72646358</jahia.nexus.staging.repository.id>
     </properties>
 
     <scm>
@@ -100,15 +102,39 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.8,)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[11,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>5.1.9</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -118,32 +144,10 @@
                     </instructions>
                 </configuration>
             </plugin>
-            
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.0-beta-3</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <doCheck>false</doCheck>
-                    <doUpdate>false</doUpdate>
-                    <useLastCommittedRevision>true</useLastCommittedRevision>
-                    <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
-                    <revisionOnScmFailure>00000</revisionOnScmFailure>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.0.4</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -153,7 +157,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 
@@ -166,10 +169,26 @@
             <id>jahia-snapshots</id>
             <url>https://devtools.jahia.com/nexus/content/repositories/jahia-snapshots</url>
         </snapshotRepository>
-        <site>
-            <id>jahia.website</id>
-            <url>file://${jahia.site.path}</url>
-        </site>
     </distributionManagement>
 
+    <profiles>
+        <profile>
+            <id>release-to-staging-repository</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <nexusUrl>https://devtools.jahia.com/nexus/</nexusUrl>
+                            <serverId>staging-repository</serverId>
+                            <stagingProfileId>${jahia.nexus.staging.repository.id}</stagingProfileId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Description

This pull request makes significant updates to the CI/CD workflows and the `pom.xml` file to modernize the build process and align with updated dependencies. The most important changes include upgrading the Java version used across workflows, simplifying the release workflow by reusing a shared configuration, and modernizing the Maven build configuration with updated plugins and profiles.

### CI/CD Workflow Updates:
* Upgraded the container image in `.github/workflows/on-code-change.yml` and `.github/workflows/on-merge.yml` to use Java 11 (`jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node`) instead of Java 8. This ensures compatibility with modern Java features and libraries. [[1]](diffhunk://#diff-702cf59f337a533d1fb9ff8867d04a602721155ac628f30edc43e5e18bfa2b14L37-R37) [[2]](diffhunk://#diff-52f2d11ee9848eab8314dccf0822c7852a568fed99f06737c13aa214c3ab1fb8L30-R30) [[3]](diffhunk://#diff-52f2d11ee9848eab8314dccf0822c7852a568fed99f06737c13aa214c3ab1fb8L48-R48)
* Replaced the custom release workflow in `.github/workflows/on-release.yml` with a reusable workflow (`Jahia/jahia-modules-action/.github/workflows/reusable-release-module.yml@v2`). This simplifies maintenance and ensures consistency across projects.

### Maven Build Configuration Updates:
* Updated the `pom.xml` to use Java 11 for compilation (`<source>` and `<target>` set to `11`) and added the Maven Enforcer Plugin to enforce minimum versions for Maven (3.8+) and Java (11+).
* Upgraded various Maven plugins, including `maven-compiler-plugin` (to 3.14.0), `maven-bundle-plugin` (to 5.1.9), and `maven-source-plugin` (to 3.3.1). Removed the deprecated `buildnumber-maven-plugin`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R105-R137) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L121-R150)
* Introduced a new Maven profile (`release-to-staging-repository`) to handle staging repository configurations for releases. This uses the `nexus-staging-maven-plugin` for streamlined deployment.

These changes collectively modernize the build and release process, ensuring better maintainability and alignment with current best practices.